### PR TITLE
Fix elixir compiler warnings

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -7,8 +7,8 @@ defmodule Haiku.Mixfile do
      elixir: "~> 1.3",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     description: description,
-     package: package,
+     description: description(),
+     package: package(),
      deps: deps()]
   end
 


### PR DESCRIPTION
Recent elixir versions generate compile time warnings. This adds the missing parentheses.

```
warning: variable "description" does not exist and is being expanded to "description()", please use parentheses to remove the ambiguity or change the variable name
 /app/deps/haiku/mix.exs:10: Haiku.Mixfile.project/0

warning: variable "package" does not exist and is being expanded to "package()", please use parentheses to remove the ambiguity or change the variable name
  /app/deps/haiku/mix.exs:11: Haiku.Mixfile.project/0

==> haiku
Compiling 2 files (.ex)
Generated haiku app
```
